### PR TITLE
Fix caching issues

### DIFF
--- a/src/BitbucketFactory.php
+++ b/src/BitbucketFactory.php
@@ -16,6 +16,7 @@ namespace GrahamCampbell\Bitbucket;
 use Bitbucket\Client;
 use Bitbucket\HttpClient\Builder;
 use GrahamCampbell\Bitbucket\Authenticators\AuthenticatorFactory;
+use GrahamCampbell\Bitbucket\Http\Psr16Cache;
 use Http\Client\Common\Plugin\RetryPlugin;
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Support\Arr;
@@ -30,6 +31,20 @@ use Symfony\Component\Cache\Adapter\SimpleCacheAdapter;
  */
 class BitbucketFactory
 {
+    /**
+     * The minimum cache lifetime of 12 hours.
+     *
+     * @var int
+     */
+    const MIN_CACHE_LIFETIME = 43200;
+
+    /**
+     * The maximum cache lifetime of 48 hours.
+     *
+     * @var int
+     */
+    const MAX_CACHE_LIFETIME = 172800;
+
     /**
      * The authenticator factory instance.
      *
@@ -119,6 +134,8 @@ class BitbucketFactory
     {
         $store = $this->cache->store($name === true ? null : $name);
 
-        return class_exists(Psr16Adapter::class) ? new Psr16Adapter($store) : new SimpleCacheAdapter($store);
+        $repo = new Psr16Cache($store, self::MIN_CACHE_LIFETIME, self::MAX_CACHE_LIFETIME);
+
+        return class_exists(Psr16Adapter::class) ? new Psr16Adapter($repo) : new SimpleCacheAdapter($repo);
     }
 }

--- a/src/Http/Psr16Cache.php
+++ b/src/Http/Psr16Cache.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Laravel Bitbucket.
+ *
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace GrahamCampbell\Bitbucket\Http;
+
+use Illuminate\Contracts\Cache\Repository;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * This is the PSR-16 cache class.
+ *
+ * The purpose of this class is to work around bugs present in Laravel
+ * 5.5.0-5.5.47, 5.6.x and 5.7.x, and 5.8.0-5.8.32, and also to enforce a
+ * maximum TTL on cache items.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ */
+class Psr16Cache implements CacheInterface
+{
+    /**
+     * The underlying cache instance.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected $cache;
+
+    /**
+     * Create a PSR-16 cache instance.
+     *
+     * @param \Illuminate\Contracts\Cache\Repository $cache
+     * @param int                                    $min
+     * @param int                                    $max
+     *
+     * @return void
+     */
+    public function __construct(Repository $cache, int $min, int $max)
+    {
+        $this->cache = $cache;
+        $this->min = $min;
+        $this->max = $max;
+    }
+
+    /**
+     * Computes the TTL to use.
+     *
+     * @param null|int|\DateInterval $ttl
+     *
+     * @return int
+     */
+    protected function computeTtl($ttl)
+    {
+        return TtlHelper::computeTtl($this->min, $this->max, $ttl);
+    }
+
+    /**
+     * Fetches a value from the cache.
+     *
+     * @param string $key
+     * @param mixed  $default
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        return $this->cache->get($key, $default);
+    }
+
+    /**
+     * Persists data in the cache, uniquely referenced by a key.
+     *
+     * @param string                 $key
+     * @param mixed                  $value
+     * @param null|int|\DateInterval $ttl
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *
+     * @return bool
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        return $this->cache->put($key, $value, $this->computeTtl($ttl));
+    }
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *
+     * @return bool
+     */
+    public function delete($key)
+    {
+        return $this->cache->forget($key);
+    }
+
+    /**
+     * Wipes clean the entire cache's keys.
+     *
+     * @return bool
+     */
+    public function clear()
+    {
+        return $this->cache->clear();
+    }
+
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable $keys
+     * @param mixed    $default
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *
+     * @return iterable
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $defaults = [];
+
+        foreach ($keys as $key) {
+            $defaults[$key] = $default;
+        }
+
+        return $this->cache->many($defaults);
+    }
+
+    /**
+     * Persists a set of key => value pairs in the cache.
+     *
+     * @param iterable               $values
+     * @param null|int|\DateInterval $ttl
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *
+     * @return bool
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $values = is_array($values) ? $values : iterator_to_array($values);
+
+        return $this->cache->putMany($values, $this->computeTtl($ttl));
+    }
+
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable $keys
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *
+     * @return bool
+     */
+    public function deleteMultiple($keys)
+    {
+        return $this->cache->deleteMultiple($keys);
+    }
+
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * @param string $key
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *
+     * @return bool
+     */
+    public function has($key)
+    {
+        return $this->cache->has($key);
+    }
+}

--- a/src/Http/TtlHelper.php
+++ b/src/Http/TtlHelper.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Laravel Bitbucket.
+ *
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace GrahamCampbell\Bitbucket\Http;
+
+use DateInterval;
+use DateTimeImmutable;
+use Illuminate\Contracts\Cache\Repository;
+use ReflectionClass;
+
+/**
+ * This is TTL helper.
+ *
+ * The purpose of this class is to detect if the Laravel cache repository is
+ * working with minutes or seconds, and also to enforce a min and max TTL.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ */
+class TtlHelper
+{
+    /**
+     * Computes the correct TTL to use.
+     *
+     * @param int                    $min
+     * @param int                    $max
+     * @param null|int|\DateInterval $ttl
+     *
+     * @return int
+     */
+    public static function computeTtl(int $min, int $max, $ttl = null)
+    {
+        if ($ttl instanceof DateInterval) {
+            $ttl = self::dateIntervalToSeconds($ttl);
+        }
+
+        $ttl = max($min, min($ttl ?: $min, $max));
+
+        return self::isLegacy() ? (int) floor($ttl / 60.0) : $ttl;
+    }
+
+    /**
+     * Convert a date interval to seconds.
+     *
+     * @param \DateInterval $ttl
+     *
+     * @return int
+     */
+    private static function dateIntervalToSeconds(DateInterval $ttl)
+    {
+        $reference = new DateTimeImmutable();
+        $endTime = $reference->add($ttl);
+
+        return $endTime->getTimestamp() - $reference->getTimestamp();
+    }
+
+    /**
+     * If the Laravel cache repository is legacy.
+     *
+     * Legacy cache repositories work in minutes.
+     *
+     * @return bool
+     */
+    private static function isLegacy()
+    {
+        static $legacy;
+
+        if ($legacy === null) {
+            $params = (new ReflectionClass(Repository::class))->getMethod('put')->getParameters();
+            $legacy = $params[2]->getName() === 'minutes';
+        }
+
+        return $legacy;
+    }
+}


### PR DESCRIPTION
There are various bugs affecting the Laravel cache repository in Laravel versions 5.5.0-5.5.47, 5.6.x, 5.7.x, and 5.8.0-5.8.32. We want to support all 5.5.x, 5.6.x, 5.7.x, 5.8.x versions, so we will work around these bugs directly within this package.

This PR also enforces a maximum and minimum time for items to be cached for, to avoid the cache becoming full, or underused.