### PR TITLE
Fix wrong order of authenticate parameters

### DIFF
--- a/src/Auth/Authenticator/JwtAuthenticator.php
+++ b/src/Auth/Authenticator/JwtAuthenticator.php
@@ -41,7 +41,7 @@ final class JwtAuthenticator extends AbstractAuthenticator
             throw new InvalidArgumentException('The jwt authenticator requires a token.');
         }
 
-        $client->authenticate($config['token'], Client::AUTH_JWT);
+        $client->authenticate(Client::AUTH_JWT, $config['token']);
 
         return $client;
     }


### PR DESCRIPTION
The parameter order of the authenticate is `($method, $token, $password)`